### PR TITLE
Button prefix refactor

### DIFF
--- a/demo/sg-filia-demo-lang/demo-one-file.rkt
+++ b/demo/sg-filia-demo-lang/demo-one-file.rkt
@@ -1,0 +1,77 @@
+#lang racket
+
+(require "../../lib/yomi-lang.rkt")
+
+; Game
+(define-game skullgirls
+  [buttons LP MP HP LK MK HK]
+  [tick-rate 60])
+
+; Character
+(define-character filia
+  ; normals
+  
+  (move LP 5 3 7 14)
+  (move MP 13 3 9 19)
+  (move HP 12 3 11 21)
+  (move LK 9 3 7 19)
+  (move MK 10 3 9 17)
+  (move HK 19 9 14 26)
+  (move 2LP 6 3 7 7)
+  (move 2MP 13 3 9 38)
+  (move 2HP 12 3 9 32)
+  (move 2LK 7 3 7 10)
+  (move 2MK 10 18 25 24)  ; multi hit, possibly inaccurate
+  (move 2HK 12 26 11 19)
+  (move j.LP 7 4 7 7)
+  (move j.MP 11 12 29 9)  ; multi hit, possibly inaccurate
+  (move j.HP 10 8 11 15)
+  (move j.LK 7 4 7 8)
+  (move j.MK 11 15 14 19)  ; multi hit, possibly inaccurate
+  (move j.HK 13 2 13 26)
+  
+  ; throws, no idea what durations are
+  
+  (move LP+LK 7 1 0 28)
+  (move j.LP+LK 7 3 0 13)
+  
+  ; specials
+  
+  ; ringlet spike; possibly inaccurate
+  (move 236LP 28 18 28 35)
+  (move 236MP 28 18 28 35)
+  (move 236HP 28 18 28 35)
+  ; ringlet psych
+  (move 236LK 18 0 0 10)
+  ; updo, possibly inaccurate became m/h are multi hit
+  (move 623LP 8 8 9 69)
+  (move 623MP 10 10 15 69)
+  (move 623HP 13 14 29 74)
+  ; hairball
+  (move 214LK 14 14 22 29)
+  (move 214MK 14 20 24 29)
+  (move 214HK 14 32 28 29)
+  ; airball
+  (move j.214LK 13 20 25 16)
+  (move j.214MK 13 20 25 16)
+  (move j.214HK 13 20 25 16)
+  
+  ; supers, these are likely inaccurate
+  
+  ; fenrir drive
+  (move 623MP+HP 4 34 35 74)
+  ; gregor samson (different properties in air)
+  (move 214MK+HK 8 13 41 49)
+  (move j.214MK+HK 7 34 44 0)  ; variable recovery based on when she lands
+  ; tricobezoar
+  (move 214MP+HP 8 2 19 100) ; is recovery accurate?
+
+  ; aliases
+  
+  (alias fenrir 623MP+HP)
+  (alias gregor 214MK+HK)
+  (alias tricobezoar 214MP+HP)
+  (alias throw LP+LK))
+
+; Combos
+(define-combo basic-launcher LP ~ LP ~ LK ~ MP ~ HP)

--- a/demo/sg-filia-demo-lang/schema-filia.rkt
+++ b/demo/sg-filia-demo-lang/schema-filia.rkt
@@ -6,8 +6,6 @@
 
 ; Filia character schema
 (define-character filia
-  ; hacky wacky
-  (move m.9LK 0 0 0 0)
   ; normals
   
   (move LP 5 3 7 14)

--- a/lib/schemas.rkt
+++ b/lib/schemas.rkt
@@ -67,17 +67,16 @@
     [(_ name:id
         [buttons btn:id ...]
         [tick-rate tix])
+     #:with (new-btn ...) (stx-map prefix-button-id #'(btn ...))
      (define btn-list (syntax->list #'(btn ...)))
      (validate-buttons btn-list)
-     (define new-buttons (map (compose prefix-button-id syntax->datum) btn-list))
-     (define button-definitions (map create-button-definition new-buttons))
      (define tr-id (datum->syntax #'name tick-rate-id))
      #`(begin
          (begin-for-syntax
            (if game-defined?
                (error 'game "Game schema already defined")
                (flip-game-defined)))
-         (provide #,tr-id #,@new-buttons)
+         (provide #,tr-id new-btn ...)
          (define buttons-remaining '(b1 b2 b3 b4 b5 b6 b7 b8))
          (define (allocate-button)
            (if (empty? buttons-remaining)
@@ -86,7 +85,7 @@
                  (set! buttons-remaining (rest buttons-remaining))
                  next-button)))
          (define #,tr-id tix)
-         #,@button-definitions)]
+         (define new-btn (allocate-button)) ...)]
     [stx
      (raise-syntax-error 'define-game "Bad game schema" #'stx)]))
 
@@ -123,7 +122,10 @@
 ;; prefix-button-id : Id -> Id
 ;; Prefixes the given identifier with "button:"
 (define-for-syntax (prefix-button-id button)
-  (string->symbol (string-append "button:" (symbol->string button))))
+  (let [(button-name-string (symbol->string (syntax->datum button)))]
+    (datum->syntax button
+                   (string->symbol (string-append "button:"
+                                                  button-name-string)))))
 
 ;; create-button-ids : Id -> Sexpr
 ;; Create Sexpr for the button definition

--- a/lib/schemas.rkt
+++ b/lib/schemas.rkt
@@ -127,11 +127,6 @@
                    (string->symbol (string-append "button:"
                                                   button-name-string)))))
 
-;; create-button-ids : Id -> Sexpr
-;; Create Sexpr for the button definition
-(define-for-syntax (create-button-definition button)
-  `(define ,button (allocate-button)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; CHARACTER SCHEMA ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-syntax define-character

--- a/lib/schemas.rkt
+++ b/lib/schemas.rkt
@@ -67,7 +67,7 @@
     [(_ name:id
         [buttons btn:id ...]
         [tick-rate tix])
-     #:with (new-btn ...) (stx-map prefix-button-id #'(btn ...))
+     #:with (prefixed-btn ...) (stx-map prefix-button-id #'(btn ...))
      (define btn-list (syntax->list #'(btn ...)))
      (validate-buttons btn-list)
      (define tr-id (datum->syntax #'name tick-rate-id))
@@ -76,7 +76,7 @@
            (if game-defined?
                (error 'game "Game schema already defined")
                (flip-game-defined)))
-         (provide #,tr-id new-btn ...)
+         (provide #,tr-id prefixed-btn ...)
          (define buttons-remaining '(b1 b2 b3 b4 b5 b6 b7 b8))
          (define (allocate-button)
            (if (empty? buttons-remaining)
@@ -85,7 +85,7 @@
                  (set! buttons-remaining (rest buttons-remaining))
                  next-button)))
          (define #,tr-id tix)
-         (define new-btn (allocate-button)) ...)]
+         (define prefixed-btn (allocate-button)) ...)]
     [stx
      (raise-syntax-error 'define-game "Bad game schema" #'stx)]))
 


### PR DESCRIPTION
Changed game schemas so that the button prefixes are baked in, rather than added in the provide. Also added a single-file demo.